### PR TITLE
Fixing the hyperlinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The code was tested on a Tesla V100 16GB but should work on other cards with at 
 
 ## Quickstart
 
-In order to get started, we recommend taking a look at our notebooks: [**prompt-to-prompt_ldm**][p2p-ldm] and [**prompt-to-prompt_stable**][p2p-stable]. The notebooks contain end-to-end examples of usage of prompt-to-prompt on top of *Latent Diffusion* and *Stable Diffusion* respectively. Take a look at these notebooks to learn how to use the different types of prompt edits and understand the API.
+In order to get started, we recommend taking a look at our notebooks: [**prompt-to-prompt_ldm**](prompt-to-prompt_ldm.ipynb) and [**prompt-to-prompt_stable**](prompt-to-prompt_stable.ipynb). The notebooks contain end-to-end examples of usage of prompt-to-prompt on top of *Latent Diffusion* and *Stable Diffusion* respectively. Take a look at these notebooks to learn how to use the different types of prompt edits and understand the API.
 
 ## Prompt Edits
 


### PR DESCRIPTION
The hyperlinks to the notebooks in the Quick Start section are now fixed!